### PR TITLE
use pytest's tmpdir and test for warning

### DIFF
--- a/sherpa/astro/ui/tests/test_astro_ui_utils_unit.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_utils_unit.py
@@ -24,7 +24,6 @@
 #
 
 import os
-import tempfile
 
 import pytest
 
@@ -32,8 +31,6 @@ import pytest
 
 from sherpa.astro import ui
 from sherpa.utils import requires_data, requires_fits, requires_xspec
-
-tmpdir = tempfile.gettempdir()
 
 
 # Note that the logic in load_table_model is quite convoluted,
@@ -48,38 +45,32 @@ tmpdir = tempfile.gettempdir()
 #
 
 @requires_fits
-@pytest.mark.skipif(not(os.path.isdir(tmpdir)),
-                    reason='temp directory does not exist')
-def test_load_table_model_fails_with_dir():
+def test_load_table_model_fails_with_dir(tmpdir):
     """Check that the function fails with invalid input: directory
 
-    The temporary directory is used for this (the test is skipped if
-    it does not exist).
+    The temporary directory is used for this.
     """
 
     ui.clean()
     assert ui.list_model_components() == []
     with pytest.raises(IOError):
-        ui.load_table_model('tmpdir', tmpdir)
+        ui.load_table_model('tmpdir', str(tmpdir))
 
     assert ui.list_model_components() == []
 
 
 @requires_fits
 @requires_xspec
-@pytest.mark.skipif(not(os.path.isdir(tmpdir)),
-                    reason='temp directory does not exist')
-def test_load_xstable_model_fails_with_dir():
+def test_load_xstable_model_fails_with_dir(tmpdir):
     """Check that the function fails with invalid input: directory
 
-    The temporary directory is used for this (the test is skipped if
-    it does not exist).
+    The temporary directory is used for this.
     """
 
     ui.clean()
     assert ui.list_model_components() == []
     with pytest.raises(IOError):
-        ui.load_xstable_model('tmpdir', tmpdir)
+        ui.load_xstable_model('tmpdir', str(tmpdir))
 
     assert ui.list_model_components() == []
 

--- a/sherpa/astro/xspec/tests/test_xspec.py
+++ b/sherpa/astro/xspec/tests/test_xspec.py
@@ -16,7 +16,7 @@
 #  with this program; if not, write to the Free Software Foundation, Inc.,
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
-
+import pytest
 import numpy
 from numpy.testing import assert_allclose, assert_array_equal
 from sherpa.astro import ui
@@ -398,7 +398,8 @@ class test_xspec(SherpaTestCase):
     @requires_data
     @requires_fits
     def test_xspec_tablemodel(self):
-        self._test_xspec_tablemodel(ui.load_table_model)
+        with pytest.warns(DeprecationWarning):
+            self._test_xspec_tablemodel(ui.load_table_model)
 
     @requires_data
     @requires_fits


### PR DESCRIPTION
As agreed, this adds a test of the warning message actually being issued. I took the opportunity to simplify the use of a temporary directory using `pytest`'s `tmpdir` fixture.